### PR TITLE
ev_as More Flexible Arguments

### DIFF
--- a/src/ev_as.py
+++ b/src/ev_as.py
@@ -209,7 +209,7 @@ def assemble(ifpath, ofpath, script, messagepath):
     assembler = evAssembler()
     walker = ParseTreeWalker()
     walker.walk(assembler, tree)
-    unityTree = convertToUnity(assembler.scripts, assembler.strTbl, messagepath)
+    unityTree = convertToUnity(ifpath, assembler.scripts, assembler.strTbl, messagepath)
     repackUnity(ofpath, script, unityTree)
 
 def repackUnityAll(ofpath, scripts):

--- a/src/ev_as.py
+++ b/src/ev_as.py
@@ -253,7 +253,9 @@ def main():
     parser.add_argument("-i", "--input", dest='ifpath', action='store', default='scripts')
     parser.add_argument("-o", "--output", dest='ofpath', action='store', default='bin/ev_script')
     parser.add_argument("-s", "--script", dest='script', action='store')
-    parser.add_argument("-v", "--validate", dest='validate', action='store', type=bool, default=True)
+    parser.add_argument("-v", "--validate", dest='validate', action='store_true')
+    parser.add_argument("-nv", "--no-validate", dest='validate', action='store_false')
+    parser.set_defaults(validate=True)
     parser.add_argument("-m", "--message", dest='message', action='store', default='AssetFolder/english_Export')
 
     vargs = parser.parse_args()


### PR DESCRIPTION
Made the arguments more flexible  
`-i`/`--input` now supports either a directory or a single file, if a directory is passed, all scripts in that directory are assembled.  
`-o`/`--output` defaults to `bin/ev_script` this is a completed ev_script file that will have the scripts packed into it.  
`-s`/`--script` is optional, if omitted it just uses the scripts filename, same as assembling all  
New Commands  
`-v`/`--validate` and `-nv`/`--no-validate` Allows you to disable message validation  
`-m`/`--message` allows you to specify the directory where scenario json files are  