### PR TITLE
ev_as.py More Flexible Argument Parser

### DIFF
--- a/src/ev_as.py
+++ b/src/ev_as.py
@@ -34,17 +34,17 @@ class GDataManager:
             scenario2 = []
             scenario3 = []
             try:
-                with open(os.path.join(messagepath, "english_dp_scenario1.json", "r", encoding='utf-8')) as ifobj:
+                with open(os.path.join(messagepath, "english_dp_scenario1.json"), "r", encoding='utf-8') as ifobj:
                     data = json.load(ifobj)
                     for entry in data["labelDataArray"]:
                         labelName = entry["labelName"]
                         scenario1.append(labelName)
-                with open(os.path.join(messagepath, "english_dp_scenario2.json", "r", encoding='utf-8')) as ifobj:
+                with open(os.path.join(messagepath, "english_dp_scenario2.json"), "r", encoding='utf-8') as ifobj:
                     data = json.load(ifobj)
                     for entry in data["labelDataArray"]:
                         labelName = entry["labelName"]
                         scenario2.append(labelName)
-                with open(os.path.join(messagepath, "english_dp_scenario3.json", "r", encoding='utf-8')) as ifobj:
+                with open(os.path.join(messagepath, "english_dp_scenario3.json"), "r", encoding='utf-8') as ifobj:
                     data = json.load(ifobj)
                     for entry in data["labelDataArray"]:
                         labelName = entry["labelName"]

--- a/src/ev_as.py
+++ b/src/ev_as.py
@@ -209,7 +209,7 @@ def assemble(ifpath, ofpath, script, messagepath):
     assembler = evAssembler()
     walker = ParseTreeWalker()
     walker.walk(assembler, tree)
-    unityTree = convertToUnity(assembler.scripts, assembler.strTbl, messagepath)
+    unityTree = convertToUnity(ifpath, assembler.scripts, assembler.strTbl, messagepath)
     repackUnity(ofpath, script, unityTree)
 
 def repackUnityAll(ofpath, scripts):

--- a/src/ev_as.py
+++ b/src/ev_as.py
@@ -253,7 +253,9 @@ def main():
     parser.add_argument("-i", "--input", dest='ifpath', action='store', default='scripts')
     parser.add_argument("-o", "--output", dest='ofpath', action='store', default='bin/ev_script')
     parser.add_argument("-s", "--script", dest='script', action='store')
-    parser.add_argument("-v", "--validate", dest='validate', action='store', type=bool, default=True)
+    parser.add_argument("-v", "--validate", dest='validate', action='store_true')
+    parser.add_argument("-nv", "--no-validate", dest='validate', action='store_false')
+    parser.set_defaults(validate=True)
     parser.add_argument("-m", "--message", dest='message', action='store', default='AssetFolder/english_Export')
 
     vargs = parser.parse_args()


### PR DESCRIPTION
Accept more flexible inputs for ev_as.py  
`-i` now accepts either a file for assembling a single file, or a directory to assemble all `.ev` scripts within.  
`-o` The output ev_script file works for both assembling a single file or multiple.  
`-s` Now optional, if omitted, it will use the base name of the script file.   
`-v` and `-nv` to enable and disable message validation.   
`-m` to set the directory where exported message `.json` files are located.  